### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = UTF-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = false


### PR DESCRIPTION
This will enforce minor formatting/encoding stuff across the code-base, and [make the lists smaller](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/discussions/608#discussioncomment-10563300)